### PR TITLE
Get ZK bundle to work in a clustered environment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import ByteConversions._
 
 organization := "com.typesafe.zookeeper"
 name := "zookeeper"
-version := "3.4.8"
+version := "3.5.2-alpha"
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-libraryDependencies += "org.apache.zookeeper" % "zookeeper" % "3.4.8"
+libraryDependencies += "org.apache.zookeeper" % "zookeeper" % "3.5.2-alpha"
 libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.18"
 libraryDependencies += "log4j" % "log4j" % "1.2.17"
 
@@ -18,20 +18,26 @@ BundleKeys.diskSpace := 100.MB
 BundleKeys.roles := Set("zookeeper")
 
 BundleKeys.endpoints := Map(
-  "zookeeper_client" -> Endpoint("tcp", services = Set(uri("tcp://:2181")))
-//  "zookeeper_peer" ->  Endpoint("tcp", services = Set(uri("tcp://:2888"))),
-//  "zookeeper_election" -> Endpoint("tcp", services = Set(uri("tcp://:3888")))
+  "zookeeper_client" -> Endpoint("tcp", 0, "zookeeper_client", RequestAcl(Tcp(2181))),
+  "zookeeper_peer" ->  Endpoint("tcp", 0, "zookeeper_peer"),
+  "zookeeper_election" -> Endpoint("tcp", 0, "zookeeper_election")
 )
 
 BundleKeys.executableScriptPath in Bundle := (file((normalizedName in Bundle).value) / "bin" / "bootstrap").getPath
 BundleKeys.checks := Seq(uri("$ZOOKEEPER_CLIENT_HOST?retry-count=10&retry-delay=3")
 )
+BundleKeys.configurationName := "zookeeper-prod"
 
 javaOptions in Bundle := Seq.empty
 
 // Bundle publishing configuration
 
 inConfig(Bundle)(Seq(
+  bintrayVcsUrl := Some("https://github.com/typesafehub/conductr-zookeeper"),
+  bintrayOrganization := Some("typesafe")
+))
+
+inConfig(BundleConfiguration)(Seq(
   bintrayVcsUrl := Some("https://github.com/typesafehub/conductr-zookeeper"),
   bintrayOrganization := Some("typesafe")
 ))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt"      % "sbt-bintray-bundle"   % "1.0.1")
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.2.2")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-native-packager"  % "1.0.6")
+addSbtPlugin("com.typesafe.sbt"       % "sbt-bintray-bundle"   % "1.1.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr"         % "2.2.4")
+addSbtPlugin("com.typesafe.sbt"       % "sbt-native-packager"  % "1.0.6")

--- a/src/bundle-configuration/zookeeper-prod/runtime-config.sh
+++ b/src/bundle-configuration/zookeeper-prod/runtime-config.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export ZK_DATA_DIR=/var/lib/zookeeper
+export ZOO_LOG_DIR="${ZK_DATA_DIR}/logs"

--- a/src/universal/bin/bootstrap
+++ b/src/universal/bin/bootstrap
@@ -1,35 +1,96 @@
 #!/bin/bash
 set -x
-ZK_DATA_DIR='/var/lib/zookeeper'
+
 CURRENT_PATH=`dirname "$0"`
+
+if [ -z "$ZK_DATA_DIR" ]
+then
+  ZK_DATA_DIR="${CURRENT_PATH}/../data"
+  echo "ZK_DATA_DIR not set - using default $ZK_DATA_DIR"
+else
+  echo "ZK_DATA_DIR has been set to $ZK_DATA_DIR"
+fi
+
+mkdir -p ${ZK_DATA_DIR}
+# Empty the Data Dir of prev proc
+rm -rf $ZK_DATA_DIR/*
+
 export JMXDISABLE=false
-ZK_CLIENT_OTHER_IPS=(${ZOOKEEPER_CLIENT_OTHER_IPS//:/ })
-ZK_NUM_PEERS=0
-export ZOO_LOG_DIR=$ZK_DATA_DIR/logs
-# Empty the Data Dir of prev proc 
-rm -r $ZK_DATA_DIR/*
+
+if [ -z "$ZOO_LOG_DIR" ]
+then
+  export ZOO_LOG_DIR="${CURRENT_PATH}/../logs"
+  echo "ZOO_LOG_DIR not set - using default $ZOO_LOG_DIR"
+else
+  echo "ZOO_LOG_DIR has been set to $ZOO_LOG_DIR"
+fi
+
+if [ -z "${ZOO_LOG4J_PROP}" ]
+then
+  export ZOO_LOG4J_PROP="INFO, CONSOLE, ROLLINGFILE"
+  echo "ZOO_LOG4J_PROP not set - using default $ZOO_LOG4J_PROP"
+else
+  echo "ZOO_LOG4J_PROP has been set to $ZOO_LOG4J_PROP"
+fi
+
+if [ -z "${ZK_STANDALONE_ENABLED}" ]
+then
+  echo "Running in Clustered mode"
+  echo "standaloneEnabled=false" | tee -a $CURRENT_PATH/../conf/zoo.cfg
+else
+  echo "Running in Standalone mode"
+  echo "standaloneEnabled=true" | tee -a $CURRENT_PATH/../conf/zoo.cfg
+fi
+
+if [ -z "${ZK_ROLE}" ]
+then
+  ZK_ROLE=participant
+  echo "ZK_ROLE not set - using default ${ZK_ROLE}"
+else
+  echo "ZK_ROLE has been set to ${ZK_ROLE}"
+fi
+
+
+echo "clientPortAddress=$ZOOKEEPER_CLIENT_BIND_IP"  | tee -a $CURRENT_PATH/../conf/zoo.cfg
 echo "clientPort=$ZOOKEEPER_CLIENT_BIND_PORT"  | tee -a $CURRENT_PATH/../conf/zoo.cfg
 echo "dataDir=$ZK_DATA_DIR" | tee -a $CURRENT_PATH/../conf/zoo.cfg
 
-ARR_ZK_OTHER_IPS=(${ZK_CLIENT_OTHER_IPS//:/})
-for i in "${!ZK_CLIENT_OTHER_IPS[@]}"
-do
-  ZK_PEERS=${ZK_CLIENT_OTHER_IPS[$i]}
-  ((ZK_NUM_PEERS+=1))
-done
-echo $ZK_NUM_PEERS
-if [ -z "$ZK_PEERS" ]
-then #this is the first instance
-  ZK_MYID=1
-else
-  ZK_MYID=$((ZK_NUM_PEERS + 1))
-  for i in "${!ZK_NUM_PEERS}"
+# Other ZK hosts
+ARR_ZOOKEEPER_PEER_OTHER_IPS=(${ZOOKEEPER_PEER_OTHER_IPS//:/ })
+# Other ZK client ports
+ARR_ZOOKEEPER_CLIENT_OTHER_PORTS=(${ZOOKEEPER_CLIENT_OTHER_PORTS//:/ })
+# Other ZK peer ports
+ARR_ZOOKEEPER_PEER_OTHER_PORTS=(${ZOOKEEPER_PEER_OTHER_PORTS//:/ })
+# Other ZK leader election ports
+ARR_ZOOKEEPER_ELECTION_OTHER_PORTS=(${ZOOKEEPER_ELECTION_OTHER_PORTS//:/ })
+
+NUMBER_OF_OTHER_NODES=`expr ${#ARR_ZOOKEEPER_PEER_OTHER_IPS[@]}`
+
+if [ "$NUMBER_OF_OTHER_NODES" -gt "0" ]
+then
+  ZK_MYID=$((NUMBER_OF_OTHER_NODES + 1))
+  for i in ${!ARR_ZOOKEEPER_PEER_OTHER_IPS[*]}
   do
-    PEER_IP=${ZK_PEERS[$((i))]}
-    echo "server.$((i))=$PEER_IP:2888:3888" | tee -a $CURRENT_PATH/../conf/zoo.cfg
+    OTHER_ID=$((i + 1))
+    OTHER_PEER_IP="${ARR_ZOOKEEPER_PEER_OTHER_IPS[$i]}"
+    OTHER_CLIENT_PORT="${ARR_ZOOKEEPER_CLIENT_OTHER_PORTS[$i]}"
+    OTHER_PEER_PORT="${ARR_ZOOKEEPER_PEER_OTHER_PORTS[$i]}"
+    OTHER_ELECTION_PORT="${ARR_ZOOKEEPER_ELECTION_OTHER_PORTS[$i]}"
+
+    echo "server.$OTHER_ID=$OTHER_PEER_IP:$OTHER_PEER_PORT:$OTHER_ELECTION_PORT:$ZK_ROLE;$OTHER_PEER_IP:$OTHER_CLIENT_PORT" | tee -a $CURRENT_PATH/../conf/zoo.cfg
   done
+else
+  ZK_MYID=1
 fi
 
+# Declare associate the peer bind port and election port assigned to this node based on the ZK_MYID value.
+echo "server.${ZK_MYID}=${ZOOKEEPER_PEER_BIND_IP}:${ZOOKEEPER_PEER_BIND_PORT}:${ZOOKEEPER_ELECTION_BIND_PORT}:${ZK_ROLE};${ZOOKEEPER_CLIENT_BIND_IP}:${ZOOKEEPER_CLIENT_BIND_PORT}" | tee -a $CURRENT_PATH/../conf/zoo.cfg
+
+
 echo $ZK_MYID > $ZK_DATA_DIR/myid
+
+echo "ZK Server ID: ${ZK_MYID}"
+echo "ZK Server conf: $CURRENT_PATH/../conf/zoo.cfg"
+cat $CURRENT_PATH/../conf/zoo.cfg
 
 /bin/bash $CURRENT_PATH/zkServer.sh start-foreground

--- a/src/universal/conf/log4j.properties
+++ b/src/universal/conf/log4j.properties
@@ -1,0 +1,64 @@
+# Copyright 2012 The Apache Software Foundation
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, CONSOLE, ROLLINGFILE
+
+zookeeper.console.threshold=INFO
+
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=INFO
+zookeeper.log.maxfilesize=64MB
+zookeeper.log.maxbackupindex=5
+
+zookeeper.tracelog.dir=${zookeeper.log.dir}
+zookeeper.tracelog.file=zookeeper_trace.log
+
+log4j.rootLogger=${zookeeper.root.logger}
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=${zookeeper.log.maxfilesize}
+log4j.appender.ROLLINGFILE.MaxBackupIndex=${zookeeper.log.maxbackupindex}
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add TRACEFILE to rootLogger to get log file output
+#    Log TRACE level and above messages to a log file
+#
+log4j.appender.TRACEFILE=org.apache.log4j.FileAppender
+log4j.appender.TRACEFILE.Threshold=TRACE
+log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.file}
+
+log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
+### Notice we are including log4j's NDC here (%x)
+log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n


### PR DESCRIPTION
ZK version is upgraded to 3.5.2-alpha since 3.4 and below doesn't support dynamic configuration of cluster nodes, i.e. need to restart all cluster members if introducing new node.

build.sbt changes
- Expose endpoints for ZK peer and leader election - these are required to form a ZK cluster. Declare service names for these endpoints to allow for lookup as well.
- Declare ZK client with request ACLs, specifying service name so it can be looked up.

bootstrap script changes
- ZK data dir is stored under the bundle run dir by default.
- Enable ZK log files to be stored under bundle run dir by default.
- Declare ZK server id by checking number of previously started peers.
- Declare ZK servers correctly based on the bind host and ports of ZK peer and leader election endpoints for previous peers and current host.

Also add log4j.properties so logs can be displayed to stdout which in turn will be available on `conduct logs` command.

Production bundle config is added which moves the data dir and log files under `/var/lib/zookeeper`.

Also update `sbt-conductr` to 2.2.4 and `sbt-bintray-bundle` to `1.1.1`.